### PR TITLE
chore(config): Use API_HOST config

### DIFF
--- a/app/plugins/features/media/controller.js
+++ b/app/plugins/features/media/controller.js
@@ -4,9 +4,11 @@ const Moment  = require('moment');
 const Promise = require('bluebird');
 const Request = require('request-promise');
 
+const Config = require('../../../../config');
+
 exports.fetchLatest = () => {
   return Request({
-    uri: `http://aapod-api.herokuapp.com/media/latest`,
+    uri: `${Config.API_HOST}/media/latest`,
     json: true
   })
   .then((response) => {
@@ -38,7 +40,7 @@ exports.fetch = (date) => {
   }
 
   return Request({
-    uri: `http://aapod-api.herokuapp.com/media/${date}`,
+    uri: `${Config.API_HOST}/media/${date}`,
     json: true
   })
   .then((response) => {

--- a/config/development.js
+++ b/config/development.js
@@ -1,6 +1,6 @@
 'use strict';
 
 module.exports = {
-  API_HOST: 'http://aapod-api.herokuapp.com',
+  API_HOST: 'http://api.aapod.co',
   PORT: 3001
 };

--- a/config/test.js
+++ b/config/test.js
@@ -1,6 +1,6 @@
 'use strict';
 
 module.exports = {
-  API_HOST: 'http://aapod-api.herokuapp.com',
+  API_HOST: 'http://api.aapod.co',
   PORT: 3001
 };


### PR DESCRIPTION
- [x] Replace hardcoded hosts with call to `Config.API_HOST`.
- [x] Update config files to reflect new shiny domain name.