### PR TITLE
fix(heroku): Use node-sass in heroku-compatible way for build

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Front End for AAPOD",
   "main": "app/index.js",
   "scripts": {
-    "build": "node-sass app/public/scss/main.scss app/public/css/main.css",
+    "build": "node_modules/node-sass/bin/node-sass app/public/scss/main.scss app/public/css/main.css",
     "enforce": "istanbul check-coverage --statement 100 --branch 100 --function 100 --lines 100",
     "start": "yarn run build && node app/index.js",
     "test": "NODE_ENV=test istanbul cover _mocha -- test --require test/setup.js --recursive --timeout 30000"


### PR DESCRIPTION
- [x] `node-sass` can't be found on heroku, so use the command from `node_modules`.